### PR TITLE
refactor: changing references from opdev to docling-project

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,7 +43,7 @@ linters:
       - pkg: k8s.io/client-go/kubernetes/scheme
         alias: clientgoscheme
     goimports:
-      local-prefixes: github.com/opdev/docling-operator
+      local-prefixes: github.com/docling-project/docling-operator
 
   exclusions:
     generated: lax

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ RELEASE_TAG ?= "latest"
 CHANNELS="alpha"
 DEFAULT_CHANNEL="alpha"
 IMAGE_REGISTRY ?= "quay.io"
-IMAGE_REPO ?= "opdev"
+IMAGE_REPO ?= "docling-project"
 IMAGE_NAME ?= "docling-operator"
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/PROJECT
+++ b/PROJECT
@@ -9,7 +9,7 @@ plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
 projectName: docling-operator
-repo: github.io/opdev/docling-operator
+repo: github.io/docling-project/docling-operator
 resources:
 - api:
     crdVersion: v1
@@ -17,6 +17,6 @@ resources:
   controller: true
   domain: docling.github.io
   kind: DoclingServe
-  path: github.io/opdev/docling-operator/api/v1alpha1
+  path: github.io/docling-project/docling-operator/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ engine:
 ### To Deploy on the cluster
 
 ```sh
-git clone https://github.com/opdev/docling-operator.git
+git clone https://github.com/docling-project/docling-operator.git
 ```
 ```sh
 cd <project>

--- a/cmd/internal/manager/main.go
+++ b/cmd/internal/manager/main.go
@@ -20,8 +20,8 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	doclinggithubiov1alpha1 "github.io/opdev/docling-operator/api/v1alpha1"
-	"github.io/opdev/docling-operator/internal/controller"
+	doclinggithubiov1alpha1 "github.io/docling-project/docling-operator/api/v1alpha1"
+	"github.io/docling-project/docling-operator/internal/controller"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"os"
 
-	"github.io/opdev/docling-operator/cmd/internal/manager"
+	"github.io/docling-project/docling-operator/cmd/internal/manager"
 )
 
 func main() {

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/opdev/docling-operator
+  newName: quay.io/docling-project/docling-operator
   newTag: latest

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.io/opdev/docling-operator
+module github.io/docling-project/docling-operator
 
 go 1.24.1
 

--- a/internal/controller/doclingserve_controller.go
+++ b/internal/controller/doclingserve_controller.go
@@ -29,8 +29,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.io/opdev/docling-operator/api/v1alpha1"
-	"github.io/opdev/docling-operator/internal/reconcilers"
+	"github.io/docling-project/docling-operator/api/v1alpha1"
+	"github.io/docling-project/docling-operator/internal/reconcilers"
 )
 
 var log = logf.Log.WithName("controller_doclingserve")

--- a/internal/controller/doclingserve_controller_test.go
+++ b/internal/controller/doclingserve_controller_test.go
@@ -27,7 +27,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	doclinggithubiov1alpha1 "github.io/opdev/docling-operator/api/v1alpha1"
+	doclinggithubiov1alpha1 "github.io/docling-project/docling-operator/api/v1alpha1"
 )
 
 var _ = Describe("DoclingServe Controller", func() {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -34,7 +34,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	doclinggithubiov1alpha1 "github.io/opdev/docling-operator/api/v1alpha1"
+	doclinggithubiov1alpha1 "github.io/docling-project/docling-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/internal/reconcilers/deployment.go
+++ b/internal/reconcilers/deployment.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strconv"
 
-	"github.io/opdev/docling-operator/api/v1alpha1"
+	"github.io/docling-project/docling-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/reconcilers/route.go
+++ b/internal/reconcilers/route.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	routev1 "github.com/openshift/api/route/v1"
-	"github.io/opdev/docling-operator/api/v1alpha1"
+	"github.io/docling-project/docling-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/internal/reconcilers/service.go
+++ b/internal/reconcilers/service.go
@@ -7,7 +7,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.io/opdev/docling-operator/api/v1alpha1"
+	"github.io/docling-project/docling-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/internal/reconcilers/service_account.go
+++ b/internal/reconcilers/service_account.go
@@ -3,7 +3,7 @@ package reconcilers
 import (
 	"context"
 
-	"github.io/opdev/docling-operator/api/v1alpha1"
+	"github.io/docling-project/docling-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/internal/reconcilers/status.go
+++ b/internal/reconcilers/status.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	routev1 "github.com/openshift/api/route/v1"
-	"github.io/opdev/docling-operator/api/v1alpha1"
+	"github.io/docling-project/docling-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/internal/reconcilers/types.go
+++ b/internal/reconcilers/types.go
@@ -3,7 +3,7 @@ package reconcilers
 import (
 	"context"
 
-	"github.io/opdev/docling-operator/api/v1alpha1"
+	"github.io/docling-project/docling-operator/api/v1alpha1"
 )
 
 type Reconciler interface {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.io/opdev/docling-operator/test/utils"
+	"github.io/docling-project/docling-operator/test/utils"
 )
 
 const namespace = "docling-operator-system"


### PR DESCRIPTION
### Motivation
Since the organization was move, we should align to the new organizations name for consistency/usability.

### Changes
Change all references from `opdev` to `docling-project`