### PR TITLE
remove ../samples from kustomize calls since 'lastest' isn't allowed

### DIFF
--- a/api/v1alpha1/doclingserve_types.go
+++ b/api/v1alpha1/doclingserve_types.go
@@ -40,6 +40,7 @@ type APIServer struct {
 	// Image specifics which docling-serve container image to deploy.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Image",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	// +kubebuilder:validation:Required
+	// +kubebuilder:default="quay.io/docling-project/docling-serve:latest"
 	Image string `json:"image"`
 
 	// EnableUI determines whether to run the docling-serve ui.

--- a/config/crd/bases/docling.github.io_doclingserves.yaml
+++ b/config/crd/bases/docling.github.io_doclingserves.yaml
@@ -51,6 +51,7 @@ spec:
                       ui.
                     type: boolean
                   image:
+                    default: quay.io/docling-project/docling-serve:latest
                     description: Image specifics which docling-serve container image
                       to deploy.
                     type: string

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -3,7 +3,6 @@
 resources:
 - bases/docling-operator.clusterserviceversion.yaml
 - ../default
-- ../samples
 - ../scorecard
 patches:
   - path: bases/docling-operator.icon.yaml


### PR DESCRIPTION
### Motivation
When trying to cut a release I noticed the below failure, when the bundle was being built. After looking into it I released that a tag of `latest` isn't allowed in the CSV's `relatedImages` section

- https://github.com/docling-project/docling-operator/actions/runs/15114648032/job/42482757207
```
2025/05/19 13:56:19 bundle/manifests/docling-operator.clusterserviceversion.yaml - Replaced pullspec for annotation docling-serve-latest-annotation: {quay.io docling-project docling-serve latest} -> {quay.io docling-project docling-serve sha256:3b040ba402bf215718eea83ccf2172ade04b5514596ad6dee77b0c9b706bf48a}
time="2025-05-19T13:56:19Z" level=fatal msg="Error generating bundle manifests: failed to set related images: expected a map[string]interface{} type on step install path spec,install,spec,deployments"
```

### Changes
- Add a default to `spec.apiServer.image` field
- Remove `../samples` directory from the manifests kustomization

### Results
This seems to provide a better UX then we previously had in the OpenShift UI, allowing users to use either the form view or the yaml view and switch in between. We are making a tradeoff to not have the `docling-serve` workload image in the `relatedImages` section, which could affect Disconnected users in the future, but they could add that image to their pull configuration as a workaround.