### PR TITLE
Use CONTAINER_TOOL in all calls, directory in kubectl apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	$(CONTAINER_TOOL) build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ privileges or be logged in as admin.
 You can apply the samples (examples) from the config/sample:
 
 ```sh
-kubectl apply -k config/samples/docling_v1alpha1_doclingserve.yaml
+kubectl apply -k config/samples/
 ```
 
 >**NOTE**: Ensure that the samples has default values to test it out.
@@ -78,7 +78,7 @@ kubectl apply -k config/samples/docling_v1alpha1_doclingserve.yaml
 **Delete the instances (CRs) from the cluster:**
 
 ```sh
-kubectl delete -k config/samples/docling_v1alpha1_doclingserve.yaml
+kubectl delete -k config/samples/
 ```
 
 **Delete the APIs(CRDs) from the cluster:**


### PR DESCRIPTION
A couple minor fixes:

- Use `CONTAINER_TOOL` where `docker` was hardcoded in the Makefile; and
- `kubectl apply -k` must point to a directory where kustomization.yaml exists.